### PR TITLE
Add default assignee and reviewer 'javiyt' for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
 - package-ecosystem: npm
@@ -5,3 +6,7 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  assignees:
+  - javiyt
+  reviewers:
+  - javiyt


### PR DESCRIPTION
This PR adds 'javiyt' as the default assignee and reviewer for all Dependabot updates.

This ensures that Dependabot pull requests are automatically assigned to @javiyt for review.

Automated change via a script.
