### PR TITLE
Add auto-merge workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Auto-merge Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - name: Enable auto-merge for Dependabot PRs
+        run: |
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          gh pr merge --auto --merge "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow (`.github/workflows/dependabot-auto-merge.yml`) that automatically enables auto-merge for all Dependabot pull requests.

The workflow triggers on Dependabot PRs and runs `gh pr merge --auto --merge` to enable auto-merge.

**Important**: For this to work, the repository must have the following settings enabled:
- "Allow auto-merge" (Settings → General → Pull Requests)
- "Allow GitHub Actions to create and approve pull requests" (Settings → Actions → General)

The script attempted to enable these automatically, but if they are not enabled, please enable them manually.

Automated change via a script.
